### PR TITLE
Fix missing session module for imports

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+import sys
+
+_backend_app = import_module('backend.app')
+
+# Expose attributes from backend.app at this level
+globals().update(_backend_app.__dict__)
+
+# Map important submodules so imports using 'app.' work
+for submodule in ['api', 'db', 'schemas', 'core']:
+    try:
+        sys.modules[f'app.{submodule}'] = import_module(f'backend.app.{submodule}')
+    except ModuleNotFoundError:
+        pass

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,9 @@
+from .database import get_async_engine, get_async_session, get_db
+
+# Create a single engine instance for the application
+engine = get_async_engine()
+
+# Factory for creating async sessions
+AsyncSessionLocal = get_async_session()
+
+__all__ = ["engine", "AsyncSessionLocal", "get_db"]


### PR DESCRIPTION
## Summary
- add stub `app` package that forwards to `backend.app`
- create empty `backend.__init__` for package discovery
- create `session.py` under `backend/app/db` for shared engine

## Testing
- `pytest backend/app/tests/test_emails.py::test_create_email -q` *(fails: ModuleNotFoundError/InvalidRequestError)*

------
https://chatgpt.com/codex/tasks/task_e_6843b94f836c8320adccbb3919213baf